### PR TITLE
🧹 Janitor: Fix lints, move imports, and enforce error handling

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2026-02-21: Centralized error handling via pytorrentsearch.error.report_error is mandatory, and debug prints should be avoided.

--- a/pytorrentsearch/cli.py
+++ b/pytorrentsearch/cli.py
@@ -8,23 +8,26 @@ Be creative! do whatever you want!
 - Import things from your .base module
 """
 
+from argparse import ArgumentParser
+
+from pytorrentsearch.error import report_error
+from pytorrentsearch.miner import mine_magnet_links, prettyprint_magnet
+from pytorrentsearch.search import duckduckgo, google, yandex
+from pytorrentsearch.utils import multi_iterator_pooler
+
 
 def main():  # pragma: no cover
-    from argparse import ArgumentParser
-
-    from pytorrentsearch.error import report_error
-    from pytorrentsearch.miner import mine_magnet_links, prettyprint_magnet
-    from pytorrentsearch.search import duckduckgo, google, yandex
-    from pytorrentsearch.utils import multi_iterator_pooler
-
     parser = ArgumentParser("pytorrentsearch")
     parser.add_argument("query", type=str)
     args = parser.parse_args()
-    print(args)
 
     if args.query.startswith("http"):
-        for magnet in mine_magnet_links(args.query):
-            prettyprint_magnet(magnet)
+        try:
+            for magnet in mine_magnet_links(args.query):
+                prettyprint_magnet(magnet)
+        except Exception as e:
+            report_error(e)
+            exit(1)
         exit(0)
 
     iterators = []

--- a/pytorrentsearch/miner.py
+++ b/pytorrentsearch/miner.py
@@ -1,4 +1,7 @@
 import re
+from urllib.parse import parse_qs, unquote, urlparse
+
+from pytorrentsearch.utils import get_url_content, status
 
 MAGNET_REGEXP = re.compile("magnet:\\?xt=[^\"']*")
 
@@ -25,10 +28,6 @@ def is_common_nontorrent_site(url: str):
 
 
 def mine_magnet_links(url: str):
-    from urllib.parse import unquote
-
-    from pytorrentsearch.utils import get_url_content, status
-
     if is_common_nontorrent_site(url):
         status(f"[crawler/ENONTORRNET] {url}")
         return []
@@ -44,8 +43,6 @@ def mine_magnet_links(url: str):
 
 
 def parse_magnet_link(url: str):
-    from urllib.parse import parse_qs, urlparse
-
     query = urlparse(url).query
     query_params = parse_qs(query)
     info_hash = query_params["xt"][0].replace("urn:", "").replace("btih:", "")

--- a/pytorrentsearch/search/duckduckgo.py
+++ b/pytorrentsearch/search/duckduckgo.py
@@ -1,13 +1,12 @@
 import re
+from urllib.parse import quote
+
+from pytorrentsearch.utils import get_url_content, min_wait, status
 
 LINK_REGEXP = re.compile('<a [^>]*href="([^"]*)"')
 
 
 def query_results(query: str, page=1):
-    from urllib.parse import quote
-
-    from pytorrentsearch.utils import get_url_content, min_wait, status
-
     page_links: set[str] = set()
     min_waiter = min_wait(5)
     while True:

--- a/pytorrentsearch/search/google.py
+++ b/pytorrentsearch/search/google.py
@@ -1,13 +1,12 @@
 import re
+from urllib.parse import quote
+
+from pytorrentsearch.utils import get_url_content, min_wait, status
 
 LINK_REGEXP = re.compile('<a [^>]*href="([^"]*)"')
 
 
 def query_results(query: str, page=1):
-    from urllib.parse import quote
-
-    from pytorrentsearch.utils import get_url_content, min_wait, status
-
     page_links: set[str] = set()
     min_waiter = min_wait(5)
     while True:

--- a/pytorrentsearch/search/yandex.py
+++ b/pytorrentsearch/search/yandex.py
@@ -1,13 +1,12 @@
 import re
+from urllib.parse import quote
+
+from pytorrentsearch.utils import get_url_content, min_wait, status
 
 LINK_REGEXP = re.compile('<a [^>]*href="([^"]*)"')
 
 
 def query_results(query: str, page=1):
-    from urllib.parse import quote
-
-    from pytorrentsearch.utils import get_url_content, min_wait, status
-
     page_links: set[str] = set()
     min_waiter = min_wait(5)
     while True:

--- a/pytorrentsearch/utils.py
+++ b/pytorrentsearch/utils.py
@@ -1,12 +1,17 @@
-def status(message: str):
-    from sys import stderr
+import queue
+from sys import stderr
+from threading import Thread
+from time import sleep, time
+from urllib.request import Request, urlopen
 
+from pytorrentsearch.error import report_error
+
+
+def status(message: str):
     print(f"[*] {message}", file=stderr)
 
 
 def request(url: str, timeout=10):
-    from urllib.request import Request, urlopen
-
     req = Request(
         url,
         headers={
@@ -22,16 +27,10 @@ def get_url_content(url: str, timeout=10):
 
 
 def multi_iterator_pooler(*iterators):
-    import queue
-    from threading import Thread
-    from time import sleep
-
     q = queue.Queue(maxsize=len(iterators))
     threads = []
 
     def worker(iterator):
-        from pytorrentsearch.error import report_error
-
         while True:
             try:
                 item = next(iterator)
@@ -64,8 +63,6 @@ def multi_iterator_pooler(*iterators):
 
 
 def min_wait(seconds):
-    from time import sleep, time
-
     last_time = time()
     yield None
     while True:


### PR DESCRIPTION
**What Changed:**
- Moved imports to the top level in `pytorrentsearch/cli.py`, `pytorrentsearch/miner.py`, `pytorrentsearch/utils.py`, and `pytorrentsearch/search/*.py` to adhere to PEP 8.
- Wrapped the `mine_magnet_links` call in `pytorrentsearch/cli.py` with a `try...except` block that reports errors via `pytorrentsearch.error.report_error` and exits with status 1.
- Removed a debug `print(args)` statement in `pytorrentsearch/cli.py`.
- Created `.jules/janitor.md` to track recurring maintenance tasks.

**Why This Helps:**
- Improves code readability and maintainability by organizing imports.
- Ensures that unexpected errors in the CLI are properly reported and do not cause silent failures or unhandled tracebacks.
- Cleans up debugging artifacts.
- Establishes a journal for future janitorial work.

**Before/After:**
- **Before:** Imports scattered inside functions; `cli.py` had a debug print and an unprotected potential crash point.
- **After:** Clean imports at the top; `cli.py` handles errors gracefully and reports them centrally; no debug prints.

**Verification:**
- Ran `mise run lint` (passed).
- Ran `mise run test` (passed).
- Verified that `install.sh` and `mise` artifacts are removed.

---
*PR created automatically by Jules for task [4210607846032376394](https://jules.google.com/task/4210607846032376394) started by @lucasew*